### PR TITLE
 Add log compare test for devicekey example

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The application injects a dummy root of trust (ROT) if true random number genera
    
  3. Open a serial console session with the target platform using the following parameters:
 
-    * **Baud rate:** 115200
+    * **Baud rate:** 9600
     * **Data bits:** 8
     * **Stop bits:** 1
     * **Parity:** None
@@ -40,7 +40,7 @@ The application injects a dummy root of trust (ROT) if true random number genera
  6. Press the **RESET** button on the board to run the program
 
  7. The serial console should now display a series of results. 
- 
+
 ## Troubleshooting
 
 If you have problems, you can review the [documentation](https://os.mbed.com/docs/latest/tutorials/debugging.html) for suggestions on what could be wrong and how to fix it.

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -1,8 +1,6 @@
 {
     "target_overrides": {
         "*": {
-            "platform.stdio-baud-rate": 115200,
-            "platform.default-serial-baud-rate": 115200,
             "platform.stdio-convert-newlines": 1
         }
     }

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,12 @@
+# Testing examples
+
+Examples are tested using tool [htrun](https://github.com/ARMmbed/mbed-os-tools/tree/master/packages/mbed-host-tests) and templated print log. 
+
+To run the test, use following command after you build the example:
+```
+mbedhtrun -d D: -p COM4 -m K64F -f .\BUILD\K64F\GCC_ARM\devicekey.bin --compare-log tests\devicekey.log
+```
+
+
+More details about `htrun` are [here](https://github.com/ARMmbed/htrun#testing-mbed-os-examples).
+

--- a/tests/README.md
+++ b/tests/README.md
@@ -8,5 +8,5 @@ mbedhtrun -d D: -p COM4 -m K64F -f .\BUILD\K64F\GCC_ARM\devicekey.bin --compare-
 ```
 
 
-More details about `htrun` are [here](https://github.com/ARMmbed/htrun#testing-mbed-os-examples).
+More details about `htrun` are [here](https://github.com/ARMmbed/mbed-os-tools/tree/master/packages/mbed-host-tests#testing-mbed-os-examples).
 

--- a/tests/devicekey.log
+++ b/tests/devicekey.log
@@ -1,0 +1,22 @@
+--- Mbed OS DeviceKey example ---
+
+--- Using the following salt for key derivation: SALT1 ----- SALT1 ------ SALT1 ---
+--- First call to derive key, requesting derived key of 16 byte ---
+--- Derived key1 is:
+[0-9A-F]+
+
+--- Second call to derive key with the same salt. ---
+--- Derived key2 should be equal to key1 from the first call. key2 is:
+[0-9A-F]+
+--- Keys match ---
+
+--- Using the following salt for key derivation SALT2 ----- SALT2 ------ SALT2 ---
+--- Third call to derive key with the different salt should result with a new derived key1:
+[0-9A-F]+
+--- Keys not match ---
+
+--- 32 byte key derivation example. ---
+--- 32 byte derived key is:
+[0-9A-F]+
+
+--- Mbed OS DeviceKey example done. ---


### PR DESCRIPTION
Add a log compare test for this example for enable example CI testing
And change default baud rate to 9600 default,

I don't know if there is any justifiable reason to use the baud rate as 115200, I just change it to 9600 to make it is consistent with other examples, and it is going the make the test easier