### PR TITLE
CMake: Use renamed Mbed CMake targets component

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,8 @@ set(MBED_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/mbed-os CACHE INTERNAL "")
 set(MBED_CONFIG_PATH ${CMAKE_CURRENT_SOURCE_DIR}/.mbedbuild CACHE INTERNAL "")
 set(APP_TARGET mbed-os-example-devicekey)
 
+include(${MBED_ROOT}/tools/cmake/app.cmake)
+
 add_subdirectory(${MBED_ROOT})
 
 add_executable(${APP_TARGET})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,10 +24,11 @@ target_sources(${APP_TARGET}
 )
 
 target_link_libraries(${APP_TARGET}
-    mbed-os
-    mbed-os-storage-qspif
-    mbed-os-device_key
-    mbed-os-mbedtls
+    PRIVATE
+        mbed-os
+        mbed-storage-qspif
+        mbed-device_key
+        mbed-mbedtls
 )
 
 mbed_generate_bin_hex(${APP_TARGET})


### PR DESCRIPTION
They are now prefixed with "mbed-" instead of "mbed-os-"

Reviewers
@0xc0170 