### PR TITLE
CMake: Use Mbed OS path variable provided by mbed_config.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,9 +3,6 @@
 
 cmake_minimum_required(VERSION 3.18.2 FATAL_ERROR)
 
-# TODO: @mbed-os-tools MBED_ROOT and MBED_CONFIG_PATH should probably come from mbedtools
-set(MBED_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/mbed-os CACHE INTERNAL "")
-set(MBED_CONFIG_PATH ${CMAKE_CURRENT_SOURCE_DIR}/.mbedbuild CACHE INTERNAL "")
 set(APP_TARGET mbed-os-example-devicekey)
 
 include(${MBED_ROOT}/tools/cmake/app.cmake)


### PR DESCRIPTION
The tools has been updated to provide the path to the local Mbed OS program
using a CMake variable.

Reviewers
@0xc0170